### PR TITLE
Make the UI service private

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -244,7 +244,7 @@ services:
     fromDatabase:
       name: temporal-db
       property: host
-- type: web
+- type: pserv
   name: temporal-ui
   autoDeploy: false
   plan: Starter


### PR DESCRIPTION
For more security. Users can use SSH port forwarding (via the worker service) to connect. There's a corresponding PR to update https://render.com/docs/deploy-temporal.