### PR TITLE
Add optional rest-to-grpc-proxy web service for external access

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -261,6 +261,25 @@ services:
       name: temporal-frontend
       type: pserv
       property: host
+# For secure external access to the Temporal Workflow Service via REST
+# See https://github.com/render-examples/temporal-rest-proxy
+# - type: web
+#   name: rest-to-grpc-proxy
+#   repo: https://github.com/render-examples/temporal-rest-proxy
+#   autoDeploy: false
+#   plan: Starter
+#   region: oregon
+#   env: go
+#   buildCommand: go build rest-proxy/main.go
+#   startCommand: ./main
+#   envVars:
+#   - key: TEMPORAL_CLUSTER_HOST
+#     fromService:
+#       name: temporal-frontend
+#       type: pserv
+#       property: host
+#   - key: AUTH_TOKEN
+#     sync: false
 - type: web
   repo: https://github.com/render-examples/sample-temporal-app
   name: app-workflow-trigger


### PR DESCRIPTION
Some people require access to the Temporal workflow service from outside Render. If using Tailscale isn't a viable option, e.g. because they want to trigger workflows via serverless functions, then they can uncomment this block to add a `rest-to-grpc-proxy` web service to their Blueprint. The service exposes a REST API, and includes an `AUTH_TOKEN` meant to be used as a bearer token in API requests. API docs are available at https://temporal-rest-api-docs.onrender.com/.

https://github.com/render-examples/temporal-rest-proxy is a fork of the Temporal UI server, which is already using [gRPC-Gateway](https://grpc-ecosystem.github.io/grpc-gateway/) to create a REST API meant for consumption by the Temporal web UI. With a few tweaks and a new entrypoint, we can adapt this code for our purposes. See [this PR](https://github.com/render-examples/temporal-rest-proxy/pull/1) and in particular [this commit](https://github.com/render-examples/temporal-rest-proxy/pull/1/commits/38137c03fd9b7d927f4aa46a108997fd8f98ba08).

I'll pair this PR with an update to the README in https://github.com/render-examples/temporal-rest-proxy and the Temporal deployment guide at https://render.com/docs/deploy-temporal.