### PR TITLE
added temporal-ui to render blueprint

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -245,7 +245,7 @@ services:
       name: temporal-db
       property: host
 - type: pserv
-  name: temporal-ui
+  name: temporal-web
   autoDeploy: false
   plan: Starter
   region: oregon
@@ -257,6 +257,23 @@ services:
   - key: TEMPORAL_PERMIT_WRITE_API
     value: true
   - key: TEMPORAL_GRPC_HOST
+    fromService:
+      name: temporal-frontend
+      type: pserv
+      property: host
+- type: pserv
+  name: temporal-ui
+  autoDeploy: false
+  plan: Starter
+  region: oregon
+  env: docker
+  dockerfilePath: ./temporal-cluster/ui/Dockerfile
+  envVars:
+  - key: PORT
+    value: 8080
+  - key: TEMPORAL_PORT
+    value: 7233
+  - key: TEMPORAL_HOST
     fromService:
       name: temporal-frontend
       type: pserv

--- a/temporal-cluster/ui/Dockerfile
+++ b/temporal-cluster/ui/Dockerfile
@@ -1,0 +1,2 @@
+FROM temporalio/ui:0.8.0
+


### PR DESCRIPTION
This adds the new temporal UI as a separate service. 
To avoid confusion, I renamed the temporal-ui service to temporal-web, since that seems to be the actual name used in temporal.