### PR TITLE
Sets autoDeploy to false

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -27,6 +27,7 @@ services:
   region: oregon
   env: docker
   dockerfilePath: ./temporal-cluster/elasticsearch/Dockerfile
+  autoDeploy: false
   disk:
     name: esdata
     mountPath: /usr/share/elasticsearch/data
@@ -57,6 +58,7 @@ services:
   region: oregon
   env: docker
   dockerfilePath: ./temporal-cluster/server/auto-setup/Dockerfile
+  autoDeploy: false
   scaling:
     minInstances: 1
     maxInstances: 3
@@ -107,6 +109,7 @@ services:
   region: oregon
   env: docker
   dockerfilePath: ./temporal-cluster/server/Dockerfile
+  autoDeploy: false
   scaling:
     minInstances: 1
     maxInstances: 3
@@ -154,6 +157,7 @@ services:
   region: oregon
   env: docker
   dockerfilePath: ./temporal-cluster/server/Dockerfile
+  autoDeploy: false
   scaling:
     minInstances: 1
     maxInstances: 3
@@ -201,6 +205,7 @@ services:
   region: oregon
   env: docker
   dockerfilePath: ./temporal-cluster/server/Dockerfile
+  autoDeploy: false
   scaling:
     minInstances: 1
     maxInstances: 3
@@ -255,6 +260,7 @@ services:
   region: oregon
   env: docker
   dockerfilePath: ./temporal-cluster/web/Dockerfile
+  autoDeploy: false
   envVars:
   - key: PORT
     value: 8088
@@ -292,6 +298,7 @@ services:
   env: go
   buildCommand: go build start/main.go
   startCommand: ./main
+  autoDeploy: false
   envVars:
   - key: TEMPORAL_CLUSTER_HOST
     fromService:
@@ -306,6 +313,7 @@ services:
   env: go
   buildCommand: go build worker/main.go
   startCommand: ./main
+  autoDeploy: false
   envVars:
   - key: TEMPORAL_CLUSTER_HOST
     fromService:


### PR DESCRIPTION
By setting `autoDeploy: false` in the the `render.yaml`, we can ensure that subsequent merges to the main branch of this repository will not trigger deploys for any instances that have been created and deployed by the Deploy to Render button.

However, merging this PR will trigger a final forced deployment of any instances created and deployed by the Deploy to Render button.

See [the Render docs](https://render.com/docs/deploy-to-render) for more information.

Signed-off-by: zach wick <zach@render.com>